### PR TITLE
App not compatible with 32bit architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ You can configure Bibliogram by editing this file `/var/www/bibliogram/config.js
 * x86-64 - [![Build Status](https://ci-apps.yunohost.org/ci/logs/bibliogram%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/bibliogram/)
 * ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/bibliogram%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/bibliogram/)
 
+## Limitations
+
+> :warning: This package will not install in 32 bits architecture machine due to *n* framework not supporting NodeJS > v.9
+
 ## Links
 
  * Report a bug: https://github.com/YunoHost-Apps/bibliogram_ynh/issues

--- a/README_fr.md
+++ b/README_fr.md
@@ -43,6 +43,11 @@ Vous pouvez configurer Bibliogram en modifiant le fichier `/var/www/bibliogram/c
 * x86-64 - [![Build Status](https://ci-apps.yunohost.org/ci/logs/bibliogram%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/bibliogram/)
 * ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/bibliogram%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/bibliogram/)
 
+
+## Limitations
+
+> :warning: Ce package ne peut pas être installé sur une machine à architecture 32 bits car le framework *n* ne prend pas en charge NodeJS > v.9
+
 ## Liens
 
  * Signaler un bug : https://github.com/YunoHost-Apps/bibliogram_ynh/issues

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "An alternative Instagram front-end",
         "fr": "Une interface alternative pour Instagram "
     },
-    "version": "1.0.0~ynh1",
+    "version": "1.0.0~ynh2",
     "url": "https://git.sr.ht/~cadence/bibliogram",
     "license": "AGPL-3.0-only",
     "maintainer": {
@@ -14,7 +14,7 @@
         "email": "ericgaspar@free.fr"
     },
     "requirements": {
-        "yunohost": ">= 3.8.1"
+        "yunohost": ">= 4.0.0"
     },
     "multi_instance": false,
     "services": [

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -17,3 +17,27 @@ nodejs_version=12
 #=================================================
 # FUTURE OFFICIAL HELPERS
 #=================================================
+
+# Check the architecture
+#
+# example: architecture=$(ynh_detect_arch)
+#
+# usage: ynh_detect_arch
+#
+# Requires YunoHost version 2.2.4 or higher.
+
+ynh_detect_arch(){
+	local architecture
+	if [ -n "$(uname -m | grep arm64)" ] || [ -n "$(uname -m | grep aarch64)" ]; then
+		architecture="arm64"
+	elif [ -n "$(uname -m | grep 64)" ]; then
+		architecture="x86-64"
+	elif [ -n "$(uname -m | grep 86)" ]; then
+		architecture="i386"
+	elif [ -n "$(uname -m | grep arm)" ]; then
+		architecture="arm"
+	else
+		architecture="unknown"
+	fi
+	echo $architecture
+}

--- a/scripts/install
+++ b/scripts/install
@@ -34,6 +34,13 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 ynh_script_progression --message="Validating installation parameters..." --weight=1
 
+architecture=$(ynh_detect_arch)
+# Check machine architecture (in particular, we don't support 32bit machines)
+if [ $architecture == "i386" ]
+then
+	ynh_die --message="Sorry, because of NodeJS framework, this app can't be installed on i386 (32 bits) machine."
+fi
+
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die --message="This path already contains a folder"
 

--- a/scripts/remove
+++ b/scripts/remove
@@ -26,7 +26,7 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 # REMOVE SERVICE INTEGRATION IN YUNOHOST
 #=================================================
 
-# Remove the service from the list of services known by Yunohost (added from `yunohost service add`)
+# Remove the service from the list of services known by YunoHost (added from `yunohost service add`)
 if ynh_exec_warn_less yunohost service status $app >/dev/null
 then
 	ynh_script_progression --message="Removing $app service..." --weight=1
@@ -61,7 +61,7 @@ ynh_secure_remove --file="$final_path"
 #=================================================
 ynh_script_progression --message="Removing NGINX web server configuration..." --weight=5
 
-# Remove the dedicated nginx config
+# Remove the dedicated NGINX config
 ynh_remove_nginx_config
 
 #=================================================


### PR DESCRIPTION
## Problem
- *The app will not install on 32bit architecture due to n framework not supporting NodeJs > version 9*

## Solution
- *Add a ynh_die and warn about the app not compatible with 32bit architecture*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/bibliogram_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/bibliogram_ynh%20PR-NUM-%20(USERNAME)/)  
